### PR TITLE
If the protocol isn't specified in the url, add it.

### DIFF
--- a/src/io/burba/tothecomments/Application.kt
+++ b/src/io/burba/tothecomments/Application.kt
@@ -1,6 +1,7 @@
 package io.burba.tothecomments
 
 import com.ryanharter.ktor.moshi.moshi
+import io.burba.tothecomments.command.InvalidUrlException
 import io.ktor.application.Application
 import io.ktor.application.call
 import io.ktor.application.install
@@ -67,7 +68,14 @@ fun Application.module() {
 
     routing {
         get<Posts> {
-            call.respond(commands.fetchPosts.run(it.url))
+            try {
+                call.respond(commands.fetchPosts.run(it.url))
+            } catch (e: InvalidUrlException) {
+                call.respond(
+                    HttpStatusCode.BadRequest,
+                    Failure(ErrorCode.INVALID_ARGUMENTS, "Invalid URL ${it.url}")
+                )
+            }
         }
 
         install(StatusPages) {

--- a/src/io/burba/tothecomments/DI.kt
+++ b/src/io/burba/tothecomments/DI.kt
@@ -72,10 +72,9 @@ class DI(private val config: Config) {
     }
 
     private val postSources by lazy(PUBLICATION) { listOf(redditSource, hnSource) }
-    private val metaSources by lazy(PUBLICATION) { listOf(microLinkSource) }
 
     inner class Commands {
-        val fetchPosts by lazy(PUBLICATION) { FetchPostsCommand(metaSources, postSources) }
+        val fetchPosts by lazy(PUBLICATION) { FetchPostsCommand(microLinkSource, postSources) }
     }
 }
 

--- a/src/io/burba/tothecomments/ResponseTypes.kt
+++ b/src/io/burba/tothecomments/ResponseTypes.kt
@@ -1,6 +1,7 @@
 package io.burba.tothecomments
 
 enum class ErrorCode {
+    INVALID_ARGUMENTS,
     INTERNAL_SERVER_ERROR
 }
 

--- a/src/io/burba/tothecomments/command/FetchPostsCommand.kt
+++ b/src/io/burba/tothecomments/command/FetchPostsCommand.kt
@@ -1,30 +1,31 @@
 package io.burba.tothecomments.command
 
-import io.burba.tothecomments.Meta
 import io.burba.tothecomments.UrlDetails
 import io.burba.tothecomments.source.meta.MetaSource
 import io.burba.tothecomments.source.post.PostSource
-import io.burba.tothecomments.util.asyncIO
+import io.burba.tothecomments.util.coerceToUrl
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import java.net.MalformedURLException
 
-class FetchPostsCommand(private val metaSources: Iterable<MetaSource>, private val postSources: Iterable<PostSource>) {
-    suspend fun run(url: String): UrlDetails = asyncIO {
-        val metaDeferred = metaSources.map { source -> async { source.metaForUrl(url) } }
-        val postDeferred = postSources.map { source -> async { source.postsForUrl(url) } }
-        val meta = bestMeta(metaDeferred.awaitAll())
-        val posts = postDeferred.awaitAll().flatten()
+class InvalidUrlException(cause: Throwable) : Exception(cause)
+
+class FetchPostsCommand(private val metaSource: MetaSource, private val postSources: Iterable<PostSource>) {
+    @Throws(InvalidUrlException::class)
+    suspend fun run(urlStr: String): UrlDetails = coroutineScope {
+        val url = try {
+            urlStr.coerceToUrl()
+        } catch (e: MalformedURLException) {
+            throw InvalidUrlException(e)
+        }
+
+        val metaDeferred = async { metaSource.metaForUrl(url) }
+        val postDeferreds = postSources.map { source -> async { source.postsForUrl(url) } }
+
+        val meta = metaDeferred.await()
+        val posts = postDeferreds.awaitAll().flatten()
 
         UrlDetails(meta, posts)
-    }
-
-    private fun bestMeta(metas: Iterable<Meta>): Meta {
-        return metas.fold(Meta()) { best, current ->
-            best.copy(
-                title = if (best.title.isNullOrBlank()) current.title else best.title,
-                image_url = if (best.image_url.isNullOrBlank()) current.image_url else best.image_url,
-                description = if (best.description.isNullOrBlank()) current.image_url else best.description
-            )
-        }
     }
 }

--- a/src/io/burba/tothecomments/source/meta/MetaSource.kt
+++ b/src/io/burba/tothecomments/source/meta/MetaSource.kt
@@ -1,7 +1,8 @@
 package io.burba.tothecomments.source.meta
 
 import io.burba.tothecomments.Meta
+import java.net.URL
 
 interface MetaSource {
-    fun metaForUrl(url: String): Meta
+    fun metaForUrl(url: URL): Meta
 }

--- a/src/io/burba/tothecomments/source/meta/MicrolinkMetaSource.kt
+++ b/src/io/burba/tothecomments/source/meta/MicrolinkMetaSource.kt
@@ -2,13 +2,19 @@ package io.burba.tothecomments.source.meta
 
 import io.burba.tothecomments.Meta
 import io.burba.tothecomments.source.FetchException
+import io.burba.tothecomments.util.toNullIfEmpty
+import java.net.URL
 
 class MicrolinkMetaSource(private val microlinkApi: MicrolinkApi) : MetaSource {
-    override fun metaForUrl(url: String): Meta {
-        val response = microlinkApi.getMeta(url).execute()
+    override fun metaForUrl(url: URL): Meta {
+        val response = microlinkApi.getMeta(url.toString()).execute()
         if (response.isSuccessful) {
             val body = response.body() ?: throw FetchException("Unexpected empty response body")
-            return Meta(body.data.title, body.data.image?.url, body.data.description)
+            return Meta(
+                body.data.title.toNullIfEmpty(),
+                body.data.image?.url.toNullIfEmpty(),
+                body.data.description.toNullIfEmpty()
+            )
         } else {
             throw FetchException(
                 response.errorBody()?.string() ?: "Unable to fetch requested data"

--- a/src/io/burba/tothecomments/source/post/HnPostSource.kt
+++ b/src/io/burba/tothecomments/source/post/HnPostSource.kt
@@ -2,10 +2,11 @@ package io.burba.tothecomments.source.post
 
 import io.burba.tothecomments.Post
 import io.burba.tothecomments.source.FetchException
+import java.net.URL
 
 class HnPostSource(private val hnApi: HnApi): PostSource {
-    override fun postsForUrl(url: String): List<Post> {
-        val response = hnApi.getPosts(url).execute()
+    override fun postsForUrl(url: URL): List<Post> {
+        val response = hnApi.getPosts(url.toString()).execute()
         if (response.isSuccessful) {
             val body = response.body() ?: throw FetchException("Received empty response body")
             return body.hits.map { Post("https://news.ycombinator.com/item?id=${it.objectID}", it.title) }

--- a/src/io/burba/tothecomments/source/post/PostSource.kt
+++ b/src/io/burba/tothecomments/source/post/PostSource.kt
@@ -2,8 +2,9 @@ package io.burba.tothecomments.source.post
 
 import io.burba.tothecomments.Post
 import io.burba.tothecomments.source.FetchException
+import java.net.URL
 
 interface PostSource {
     @Throws(FetchException::class)
-    fun postsForUrl(url: String): List<Post>
+    fun postsForUrl(url: URL): List<Post>
 }

--- a/src/io/burba/tothecomments/source/post/RedditPostSource.kt
+++ b/src/io/burba/tothecomments/source/post/RedditPostSource.kt
@@ -6,10 +6,11 @@ import net.dean.jraw.RedditClient
 import net.dean.jraw.RedditException
 import net.dean.jraw.http.NetworkException
 import net.dean.jraw.models.SearchSort
+import java.net.URL
 
 class RedditPostSource(private val reddit: RedditClient) : PostSource {
 
-    override fun postsForUrl(url: String): List<Post> {
+    override fun postsForUrl(url: URL): List<Post> {
         val pager = reddit.search()
             .query("""url:"$url"""")
             .limit(5)

--- a/src/io/burba/tothecomments/util/StringUtil.kt
+++ b/src/io/burba/tothecomments/util/StringUtil.kt
@@ -1,0 +1,15 @@
+package io.burba.tothecomments.util
+
+import java.net.MalformedURLException
+import java.net.URL
+
+fun String.coerceToUrl(): URL {
+    return try {
+        URL(this)
+    } catch (e: MalformedURLException) {
+        // Most common case is it's missing the protocol, if it's not that, then just bail
+        URL("http://$this")
+    }
+}
+
+fun String?.toNullIfEmpty() = if (this.isNullOrEmpty()) null else this


### PR DESCRIPTION
If it's still not a valid url at that point, return an error
Remove the ability of FetchPostsCommand to fetch meta from multiple
sources, it wasn't used anyways